### PR TITLE
Add theme importing and exporting

### DIFF
--- a/src/components/Filters/Filter/DateFilter.component.tsx
+++ b/src/components/Filters/Filter/DateFilter.component.tsx
@@ -2,12 +2,12 @@ import React from "react";
 
 import { DatePicker } from "@/components/Input";
 import { useFlyout } from "@/hooks/useFlyout.hook";
+import { SIZE_MD } from "@/styles/variables";
 import { DateFilterProps } from "@/types/filters";
 import { getShortDate } from "@/utils/dates";
 import { FilterButton, FilterPill, FilterText } from "../components";
 import { FilterMenu } from "../components/Filters.styles";
 import { registerCleanupFn } from "../useFilter.hook";
-import { SIZE_MD } from "@/styles/variables";
 
 const DateFilter: React.FC<DateFilterProps> = ({
 	onModify,

--- a/src/components/Filters/Filter/DateFilter.component.tsx
+++ b/src/components/Filters/Filter/DateFilter.component.tsx
@@ -7,6 +7,7 @@ import { getShortDate } from "@/utils/dates";
 import { FilterButton, FilterPill, FilterText } from "../components";
 import { FilterMenu } from "../components/Filters.styles";
 import { registerCleanupFn } from "../useFilter.hook";
+import { SIZE_MD } from "@/styles/variables";
 
 const DateFilter: React.FC<DateFilterProps> = ({
 	onModify,
@@ -88,7 +89,7 @@ const DateFilter: React.FC<DateFilterProps> = ({
 				</li>
 			</FilterMenu>
 			<FilterButton
-				borderRadiusCorners={{ topRight: "2rem", bottomRight: "2rem" }}
+				borderRadiusCorners={{ topRight: SIZE_MD, bottomRight: SIZE_MD }}
 				filledIn={endOpen}
 				onMouseEnter={() => setEndSoftOpen(true)}
 				onMouseLeave={() => setEndSoftOpen(false)}

--- a/src/components/Filters/Filter/KeywordFilter.component.tsx
+++ b/src/components/Filters/Filter/KeywordFilter.component.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { useFlyout } from "@/hooks/useFlyout.hook";
+import { SIZE_MD } from "@/styles/variables";
 import { KeywordFilterProps } from "@/types/filters";
 import {
 	FilterButton,
@@ -10,7 +11,6 @@ import {
 	MultipleChoice,
 } from "../components";
 import { registerCleanupFn } from "../useFilter.hook";
-import { SIZE_MD } from "@/styles/variables";
 
 const MAX_KEYWORDS = 1;
 

--- a/src/components/Filters/Filter/KeywordFilter.component.tsx
+++ b/src/components/Filters/Filter/KeywordFilter.component.tsx
@@ -10,6 +10,7 @@ import {
 	MultipleChoice,
 } from "../components";
 import { registerCleanupFn } from "../useFilter.hook";
+import { SIZE_MD } from "@/styles/variables";
 
 const MAX_KEYWORDS = 1;
 
@@ -68,7 +69,7 @@ const KeywordFilter: React.FC<KeywordFilterProps> = ({
 				/>
 			</FilterMenu>
 			<FilterButton
-				borderRadiusCorners={{ topRight: "2rem", bottomRight: "2rem" }}
+				borderRadiusCorners={{ topRight: SIZE_MD, bottomRight: SIZE_MD }}
 				width="10rem"
 				filledIn={keywordsOpen}
 				onMouseEnter={() => setKeywordsSoftOpen(true)}

--- a/src/components/Filters/Filter/NewFilter.component.tsx
+++ b/src/components/Filters/Filter/NewFilter.component.tsx
@@ -3,7 +3,7 @@ import { styled } from "styled-components";
 
 import { FillIn } from "@/components/General";
 import { AddIcon } from "@/components/Icons";
-import { SIZE_SM, TRANSITION_SLOW, Z_HIGH } from "@/styles/variables";
+import { SIZE_MD, SIZE_SM, TRANSITION_SLOW, Z_HIGH } from "@/styles/variables";
 import { FilterOption, NewFilterProps } from "@/types/filters";
 import {
 	FilterMenu,
@@ -106,10 +106,10 @@ const NewFilter = React.forwardRef<HTMLButtonElement, NewFilterProps>(
 				</FilterMenu>
 				<FillIn
 					borderRadiusCorners={{
-						bottomLeft: "2rem",
-						bottomRight: "2rem",
-						topLeft: "2rem",
-						topRight: "2rem",
+						bottomLeft: SIZE_MD,
+						bottomRight: SIZE_MD,
+						topLeft: SIZE_MD,
+						topRight: SIZE_MD,
 					}}
 				>
 					<InnerContainer ref={ref}>

--- a/src/components/Filters/Filter/SearchFilter.component.tsx
+++ b/src/components/Filters/Filter/SearchFilter.component.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import { Text } from "@/components/Input";
 import { useFlyout } from "@/hooks/useFlyout.hook";
+import { SIZE_MD } from "@/styles/variables";
 import { SearchFilterProps } from "@/types/filters";
 import {
 	FilterButton,
@@ -10,7 +11,6 @@ import {
 	FilterText,
 } from "../components";
 import { registerCleanupFn } from "../useFilter.hook";
-import { SIZE_MD } from "@/styles/variables";
 
 const SearchFilter: React.FC<SearchFilterProps> = ({
 	onSearch,

--- a/src/components/Filters/Filter/SearchFilter.component.tsx
+++ b/src/components/Filters/Filter/SearchFilter.component.tsx
@@ -10,6 +10,7 @@ import {
 	FilterText,
 } from "../components";
 import { registerCleanupFn } from "../useFilter.hook";
+import { SIZE_MD } from "@/styles/variables";
 
 const SearchFilter: React.FC<SearchFilterProps> = ({
 	onSearch,
@@ -52,7 +53,7 @@ const SearchFilter: React.FC<SearchFilterProps> = ({
 				<Text label="Search" name={id} value={search} onChange={onSearch} />
 			</FilterMenu>
 			<FilterButton
-				borderRadiusCorners={{ topRight: "2rem", bottomRight: "2rem" }}
+				borderRadiusCorners={{ topRight: SIZE_MD, bottomRight: SIZE_MD }}
 				width="10rem"
 				filledIn={searchOpen}
 				onMouseEnter={() => setSearchSoftOpen(true)}

--- a/src/components/Filters/Pagination/CurrentPage.component.tsx
+++ b/src/components/Filters/Pagination/CurrentPage.component.tsx
@@ -3,7 +3,7 @@ import { styled } from "styled-components";
 
 import { FillIn } from "@/components/General";
 import { NextIcon, PreviousIcon } from "@/components/Icons";
-import { FONT_SIZE_XS, SIZE_XS } from "@/styles/variables";
+import { FONT_SIZE_XS, SIZE_MD, SIZE_XS } from "@/styles/variables";
 import { CurrentPageProps } from "@/types/filters";
 import { clamp } from "@/utils/numbers";
 import { StyledFilterPill } from "../components/FilterPill.component";
@@ -70,7 +70,7 @@ const CurrentPage = React.forwardRef<HTMLInputElement, CurrentPageProps>(
 			<StyledFilterPill style={{ backgroundColor: "white" }}>
 				<FillIn
 					disabled={previousDisabled}
-					borderRadiusCorners={{ topLeft: "2rem", bottomLeft: "2rem" }}
+					borderRadiusCorners={{ topLeft: SIZE_MD, bottomLeft: SIZE_MD }}
 				>
 					<DirectionButton
 						aria-label="Previous Page"
@@ -99,7 +99,7 @@ const CurrentPage = React.forwardRef<HTMLInputElement, CurrentPageProps>(
 				</PageCount>
 				<FillIn
 					disabled={nextDisabled}
-					borderRadiusCorners={{ topRight: "2rem", bottomRight: "2rem" }}
+					borderRadiusCorners={{ topRight: SIZE_MD, bottomRight: SIZE_MD }}
 				>
 					<DirectionButton
 						aria-label="Next Page"

--- a/src/components/Filters/components/FilterPill.component.tsx
+++ b/src/components/Filters/components/FilterPill.component.tsx
@@ -25,7 +25,7 @@ const FilterPill = React.forwardRef<HTMLDivElement, FilterPillProps>(
 		return (
 			<StyledFilterPill ref={ref}>
 				<FilterButton
-					borderRadiusCorners={{ topLeft: "2rem", bottomLeft: "2rem" }}
+					borderRadiusCorners={{ topLeft: SIZE_MD, bottomLeft: SIZE_MD }}
 					type="button"
 					onClick={onRemove}
 				>

--- a/src/components/General/IconButton/IconButton.component.tsx
+++ b/src/components/General/IconButton/IconButton.component.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import styled from "styled-components";
+
+import { FillIn } from "@/components/General";
+import { FONT_SIZE_MD, SIZE_MD, SIZE_SM } from "@/styles/variables";
+import { BorderRadiusCorners } from "@/types/filters";
+
+const StyledIconButton = styled.button<{ $width?: string }>`
+	display: flex;
+	gap: ${SIZE_SM};
+	align-items: center;
+	
+	width: ${({ $width }) => $width || "fit-content"};
+
+    padding: ${SIZE_SM};
+    
+    border: 1px solid ${({ theme }) => theme.base.border};
+    border-radius: ${SIZE_MD};
+`;
+
+const IconContainer = styled.div`
+	width: 1.5rem;
+	height: 1.5rem;
+
+	display: grid;
+	place-items: center;
+`;
+
+const TextContainer = styled.span`
+	font-size: ${FONT_SIZE_MD};
+`;
+
+const IconButton: React.FC<
+	{
+		onClick: () => void;
+		icon: React.ReactNode;
+		borderRadiusCorners?: BorderRadiusCorners;
+		width?: string;
+		disabled?: boolean;
+	} & ChildrenProp
+> = ({
+	onClick,
+	icon,
+	children,
+	width,
+	borderRadiusCorners = {
+		topLeft: SIZE_MD,
+		bottomLeft: SIZE_MD,
+		topRight: SIZE_MD,
+		bottomRight: SIZE_MD,
+	},
+	disabled = false,
+}) => {
+	return (
+		<FillIn borderRadiusCorners={borderRadiusCorners}>
+			<StyledIconButton
+				disabled={disabled}
+				$width={width}
+				type="button"
+				onClick={onClick}
+			>
+				{icon && <IconContainer>{icon}</IconContainer>}
+				<TextContainer>{children}</TextContainer>
+			</StyledIconButton>
+		</FillIn>
+	);
+};
+
+export default IconButton;

--- a/src/components/General/Loading/Loading.component.tsx
+++ b/src/components/General/Loading/Loading.component.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
 
+import { SIZE_MD } from "@/styles/variables";
 import { LoadingContainer } from "./Loading.styles";
 
-const Loading: React.FC<LoadingProps> = ({ size = "2rem" }) => (
+const Loading: React.FC<LoadingProps> = ({ size = SIZE_MD }) => (
 	<LoadingContainer size={size} />
 );
 

--- a/src/components/General/index.ts
+++ b/src/components/General/index.ts
@@ -2,5 +2,6 @@ export { default as Loading } from "./Loading/Loading.component";
 export { default as GrowableUnderline } from "./GrowableUnderline/GrowableUnderline.component";
 export { default as FillIn } from "./FillIn/FillIn.component";
 export { default as Time } from "./Accessibility/Time.component";
+export { default as IconButton } from "./IconButton/IconButton.component";
 export * from "./Project";
 export * from "./Author";

--- a/src/components/Icons/Check.component.tsx
+++ b/src/components/Icons/Check.component.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+const CheckIcon: React.FC = () => (
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		fill="none"
+		viewBox="0 0 24 24"
+		strokeWidth={1.5}
+		stroke="currentColor"
+		className="size-6"
+	>
+		<title>Success</title>
+		<path
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			d="m4.5 12.75 6 6 9-13.5"
+		/>
+	</svg>
+);
+
+export default CheckIcon;

--- a/src/components/Icons/Clipboard.component.tsx
+++ b/src/components/Icons/Clipboard.component.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+const ClipBordIcon: React.FC = () => (
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		fill="none"
+		viewBox="0 0 24 24"
+		strokeWidth={1.5}
+		stroke="currentColor"
+		className="size-6"
+	>
+		<title>Copy to Clipboard</title>
+		<path
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			d="M15.666 3.888A2.25 2.25 0 0 0 13.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 0 1-.75.75H9a.75.75 0 0 1-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 0 1-2.25 2.25H6.75A2.25 2.25 0 0 1 4.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 0 1 1.927-.184"
+		/>
+	</svg>
+);
+
+export default ClipBordIcon;

--- a/src/components/Icons/index.ts
+++ b/src/components/Icons/index.ts
@@ -10,3 +10,5 @@ export { default as ResumeIcon } from "./Document.component";
 export { default as SelectIcon } from "./Select.component";
 export { default as EditIcon } from "./Edit.component";
 export { default as ShortcutsIcon } from "./Shortcuts.component";
+export { default as ClipboardIcon } from "./Clipboard.component";
+export { default as CheckIcon } from "./Check.component";

--- a/src/components/Input/Text/Text.styles.ts
+++ b/src/components/Input/Text/Text.styles.ts
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import {
 	FONT_SIZE_MD,
 	FONT_SIZE_SM,
+	SIZE_MD,
 	SIZE_SM,
 	SIZE_XS,
 	TRANSITION_NORMAL,
@@ -10,11 +11,12 @@ import {
 
 export const TextInputContainer = styled.div`
   position: relative;
-
+  margin-left: 2px;
+  
   label {
     position: absolute;
     top: 40%;
-    left: calc(${SIZE_XS} + 2.6px);
+    left: calc(${SIZE_MD} - 2px);
     transform: translateY(-40%) scale(1);
     transform-origin: left;
 
@@ -29,12 +31,17 @@ export const TextInputContainer = styled.div`
   }
 
   input {
-    padding: calc(${SIZE_SM} + ${SIZE_XS}) ${SIZE_XS} 2px;
+    padding: calc(${SIZE_SM} + ${SIZE_XS}) calc(${SIZE_MD} - 4px) 2px;
     border: 2px solid ${(props) => props.theme.base.border};
 
     font-size: ${FONT_SIZE_SM};
     color: ${(props) => props.theme.base.textColor};
     background-color: ${(props) => props.theme.base.background};
+
+    border-top-right-radius: ${SIZE_MD};
+    border-bottom-right-radius: ${SIZE_MD};
+    border-bottom-left-radius: ${SIZE_MD};
+    border-top-left-radius: ${SIZE_MD};
 
     &:hover + label,
     &:focus + label,

--- a/src/components/Layout/Search/Search.component.tsx
+++ b/src/components/Layout/Search/Search.component.tsx
@@ -61,9 +61,9 @@ const Search = React.forwardRef<HTMLDialogElement, SearchProps>(
 			if (suggestions === null || suggestions.length === 0) {
 				setSearchAutocomplete(undefined);
 
-				const randomSuggestions = autocomplete.getRandomSuggestions();
-				setSuggestions(randomSuggestions);
-
+				const levenshteinSuggestions =
+					autocomplete.getClosestLevenshteinSuggestions(query);
+				setSuggestions(levenshteinSuggestions);
 				return;
 			}
 			const allSuggestions = suggestions.map((s) => s.word);

--- a/src/components/Layout/Sidebar/components/OpenModalButton.component.tsx
+++ b/src/components/Layout/Sidebar/components/OpenModalButton.component.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import styled from "styled-components";
 
 import { GrowableUnderline } from "@/components/General";
-import { SearchIcon } from "@/components/Icons";
 import { FONT_SIZE_MD, SIZE_SM } from "@/styles/variables";
 
 const SearchButton = styled.button`

--- a/src/components/Theme/ModifyTheme/ModifyTheme.component.tsx
+++ b/src/components/Theme/ModifyTheme/ModifyTheme.component.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 
 import { useAppSelector } from "@/store/hooks";
 import { fadeIn } from "@/styles/animations";
-import { BigParagraph } from "@/styles/general-components";
+import { BigParagraph, Subtitle } from "@/styles/general-components";
 import { FONT_MD } from "@/styles/variables";
 import ThemeSettings from "./ThemeSettings.component";
 
@@ -23,15 +23,18 @@ const ModifyTheme: React.FC<ModifyThemeProps> = ({ selectedTheme }) => {
 	const theme = themes.find((theme) => theme.id === selectedTheme);
 
 	return (
-		<ControlsContainer>
-			{theme ? (
-				<ThemeAppearance>
-					<ThemeSettings theme={theme} />
-				</ThemeAppearance>
-			) : (
-				<BigParagraph>Select a theme to modify it here</BigParagraph>
-			)}
-		</ControlsContainer>
+		<>
+			<Subtitle style={{ marginBottom: 0 }}>Modify Theme</Subtitle>
+			<ControlsContainer>
+				{theme ? (
+					<ThemeAppearance>
+						<ThemeSettings theme={theme} />
+					</ThemeAppearance>
+				) : (
+					<BigParagraph>Select a theme to modify it here</BigParagraph>
+				)}
+			</ControlsContainer>
+		</>
 	);
 };
 

--- a/src/components/Theme/ThemeControls/ThemeControl.component.tsx
+++ b/src/components/Theme/ThemeControls/ThemeControl.component.tsx
@@ -4,6 +4,7 @@ import { styled } from "styled-components";
 import { FillIn, IconButton } from "@/components/General";
 import { CheckIcon, ClipboardIcon } from "@/components/Icons";
 import { Text, Toggle } from "@/components/Input";
+import { useDebounce } from "@/hooks";
 import { useAppDispatch, useAppSelector } from "@/store/hooks";
 import {
 	importTheme,
@@ -14,7 +15,6 @@ import { Subtitle } from "@/styles/general-components";
 import { media } from "@/styles/queries";
 import { SIZE_MD, SIZE_SM, SIZE_XS } from "@/styles/variables";
 import ThemeItem from "./ThemeItem.component";
-import { useDebounce } from "@/hooks";
 
 const StyledThemeControls = styled.div`
 	display: grid;

--- a/src/components/Theme/ThemeControls/ThemeControl.component.tsx
+++ b/src/components/Theme/ThemeControls/ThemeControl.component.tsx
@@ -1,10 +1,12 @@
 import * as React from "react";
 import { styled } from "styled-components";
 
-import { FillIn } from "@/components/General";
-import { Toggle } from "@/components/Input";
+import { FillIn, IconButton } from "@/components/General";
+import { CheckIcon, ClipboardIcon } from "@/components/Icons";
+import { Text, Toggle } from "@/components/Input";
 import { useAppDispatch, useAppSelector } from "@/store/hooks";
 import {
+	importTheme,
 	resetThemeOptions,
 	toggleUseComputerPreferences,
 } from "@/store/theme/theme.slice";
@@ -12,16 +14,17 @@ import { Subtitle } from "@/styles/general-components";
 import { media } from "@/styles/queries";
 import { SIZE_MD, SIZE_SM, SIZE_XS } from "@/styles/variables";
 import ThemeItem from "./ThemeItem.component";
+import { useDebounce } from "@/hooks";
 
 const StyledThemeControls = styled.div`
 	display: grid;
 	gap: ${SIZE_SM};
 
-	grid-template-rows: auto auto 1fr;
+	grid-template-rows: repeat(3, auto) 1fr;
 
 	width: 100%;
 
-	height: 20rem;
+	height: 28rem;
 	overflow: auto;
 
 	${media.phone} {
@@ -65,6 +68,23 @@ const ThemeControls: React.FC<ThemeControlProps> = ({
 }) => {
 	const dispatch = useAppDispatch();
 	const themeStore = useAppSelector((root) => root.theme);
+	const [importedTheme, setImportedTheme] = useDebounce((val) =>
+		dispatch(importTheme(val)),
+	);
+	const [copied, setCopied] = React.useState(false);
+
+	const copyThemeToClipboard = async () => {
+		const activeTheme = themeStore.active;
+		const serialized = JSON.stringify(activeTheme);
+		const encoded = btoa(serialized);
+
+		await navigator.clipboard.writeText(encoded);
+		setCopied(true);
+		setTimeout(() => setCopied(false), 2000);
+	};
+
+	const exportIcon = copied ? <CheckIcon /> : <ClipboardIcon />;
+	const exportText = copied ? "Copied to clipboard!" : "Export Theme";
 
 	return (
 		<StyledThemeControls>
@@ -91,6 +111,22 @@ const ThemeControls: React.FC<ThemeControlProps> = ({
 					onToggle={() => dispatch(toggleUseComputerPreferences())}
 					value={!themeStore.ignoreComputerPreferences}
 				/>
+			</StyledControlContainer>
+			<StyledControlContainer>
+				<Text
+					label="Import Theme"
+					name="import-theme"
+					value={importedTheme}
+					onChange={setImportedTheme}
+				/>
+				<IconButton
+					width="12rem"
+					onClick={copyThemeToClipboard}
+					icon={exportIcon}
+					disabled={copied}
+				>
+					{exportText}
+				</IconButton>
 			</StyledControlContainer>
 			<StyledItemContainer>
 				{themeStore.themes.map((theme) => (

--- a/src/components/Theme/ThemeOptions.component.tsx
+++ b/src/components/Theme/ThemeOptions.component.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import { styled } from "styled-components";
 
 import { useAlternation } from "@/hooks";
-import { Subtitle } from "@/styles/general-components";
 import { SIZE_SM } from "@/styles/variables";
 import ModifyTheme from "./ModifyTheme/ModifyTheme.component";
 import ThemeControls from "./ThemeControls/ThemeControl.component";
@@ -21,7 +20,6 @@ const ThemeCard: React.FC = () => {
 				selectedTheme={selectedTheme}
 				setSelectedTheme={setSelectedTheme}
 			/>
-			<Subtitle style={{ marginBottom: 0 }}>Modify Theme</Subtitle>
 			<ModifyTheme selectedTheme={selectedTheme} />
 		</ThemeCardContainer>
 	);

--- a/src/store/theme/theme.slice.ts
+++ b/src/store/theme/theme.slice.ts
@@ -6,12 +6,12 @@ import {
 	STORED_THEMES,
 } from "@/data/constants";
 import { StringLookup } from "@/types/general";
+import { validateThemeShape } from "@/utils/validation";
 import { defaultDayTheme, initialState } from "./theme.state";
 import {
 	determineComputerPreferredTheme,
 	getDefaultThemeState,
 } from "./theme.utils";
-import { validateThemeShape } from "@/utils/validation";
 
 function copyTheme(
 	copiedTheme: BaseTheme,

--- a/src/store/theme/theme.slice.ts
+++ b/src/store/theme/theme.slice.ts
@@ -11,6 +11,7 @@ import {
 	determineComputerPreferredTheme,
 	getDefaultThemeState,
 } from "./theme.utils";
+import { validateThemeShape } from "@/utils/validation";
 
 function copyTheme(
 	copiedTheme: BaseTheme,
@@ -217,6 +218,30 @@ const themeSlice = createSlice({
 
 			return getDefaultThemeState();
 		},
+
+		importTheme: (state, action: PayloadAction<string>) => {
+			if (!action.payload) {
+				return;
+			}
+
+			try {
+				const decoded = atob(action.payload);
+				const importedTheme = JSON.parse(decoded);
+
+				if (!validateThemeShape(defaultDayTheme, importedTheme)) {
+					throw new Error("Invalid theme shape");
+				}
+
+				const { name, id } = copyTheme(importedTheme, state);
+				state.themes.push({ ...importedTheme, name, id: id.toString() });
+				state.latestId = id;
+
+				localStorage.setItem(STORED_THEMES, JSON.stringify(state.themes));
+				localStorage.setItem(STORED_ACTIVE_THEME_ID, id.toString());
+			} catch (e) {
+				console.error(e);
+			}
+		},
 	},
 });
 
@@ -232,6 +257,7 @@ export const {
 	changeThemeName,
 	changePropOnTheme,
 	resetThemeOptions,
+	importTheme,
 } = themeSlice.actions;
 
 export default themeSlice.reducer;

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -147,31 +147,16 @@ export class Trie {
 		return options;
 	}
 
-	// Even though this isn't used anymore, it might be useful in the future.
-	suggestByLevenshteinDistance(prefix: string): CompletionOption[] | null {
-		const options = this.getAutocompleteForSearch(prefix);
-		if (!options) {
-			return null;
-		}
-
-		return options.sort((a, b) => {
-			if (a.weight === null) {
-				return 1;
-			}
-
-			if (b.weight === null) {
-				return -1;
-			}
-
-			const aDistance = this.getLevenshteinDistance(prefix, a.word);
-			const bDistance = this.getLevenshteinDistance(prefix, b.word);
-
-			if (aDistance === bDistance) {
-				return b.weight - a.weight;
-			}
-
-			return aDistance - bDistance;
-		});
+	getClosestLevenshteinSuggestions(prefix: string): string[] {
+		const allOptionsWeighted: { word: string; weight: number }[] =
+			this.words.map((word) => ({
+				word,
+				weight: this.getLevenshteinDistance(prefix, word),
+			}));
+		return allOptionsWeighted
+			.sort((a, b) => a.weight - b.weight)
+			.slice(0, Trie.NUM_SUGGESTIONS)
+			.map((option) => option.word);
 	}
 
 	getRandomSuggestions(): string[] {

--- a/src/utils/tests/search.test.ts
+++ b/src/utils/tests/search.test.ts
@@ -133,7 +133,7 @@ describe("Trie", () => {
 		});
 	});
 
-	describe("levenshtein distance", () => {
+	describe("getLevenshteinDistance", () => {
 		beforeEach(() => {
 			trie = new Trie([
 				["apples", 5],
@@ -169,60 +169,46 @@ describe("Trie", () => {
 			expect(trie.getLevenshteinDistance("", "hello")).toBe(5);
 			expect(trie.getLevenshteinDistance("", "abc")).toBe(3);
 		});
-		it("should suggest words based on prefix and sort them by Levenshtein distance", () => {
-			expect(trie.suggestByLevenshteinDistance("a")).toEqual([
-				{
-					weight: 4,
-					word: "apply",
-				},
-				{
-					weight: 5,
-					word: "apples",
-				},
-			]);
-			expect(trie.suggestByLevenshteinDistance("ap")).toEqual([
-				{
-					weight: 4,
-					word: "apply",
-				},
-				{
-					weight: 5,
-					word: "apples",
-				},
-			]);
-			expect(trie.suggestByLevenshteinDistance("app")).toEqual([
-				{
-					weight: 4,
-					word: "apply",
-				},
-				{
-					weight: 5,
-					word: "apples",
-				},
-			]);
-			expect(trie.suggestByLevenshteinDistance("appl")).toEqual([
-				{
-					weight: 4,
-					word: "apply",
-				},
-				{
-					weight: 5,
-					word: "apples",
-				},
-			]);
-			expect(trie.suggestByLevenshteinDistance("apple")).toEqual([
-				{
-					weight: 5,
-					word: "apples",
-				},
+	});
+
+	describe("getClosestLevenshteinSuggestions", () => {
+		beforeEach(() => {
+			trie = new Trie([
+				["apples", 5],
+				["apply", 4],
+				["banana", 3],
+				["cherry", 2],
+				["orange", 1],
+				["grape", 1],
+				["kiwi", 1],
 			]);
 		});
 
-		it("should return null when no suggestions are available", () => {
-			expect(trie.suggestByLevenshteinDistance("")).toBeNull();
-			expect(trie.suggestByLevenshteinDistance("x")).toBeNull();
-			expect(trie.suggestByLevenshteinDistance("xyz")).toBeNull();
-			expect(trie.suggestByLevenshteinDistance("apples")).toBeNull();
+		it("should return the closest Levenshtein suggestions based on the prefix up to the specified amount", () => {
+			expect(trie.getClosestLevenshteinSuggestions("ap")).toEqual([
+				"apply",
+				"grape",
+				"apples",
+				"kiwi",
+				"banana",
+			]);
+		});
+
+		it("should return suggestions even when there are no similar values", () => {
+			expect(trie.getClosestLevenshteinSuggestions("xyz")).toEqual([
+				"kiwi",
+				"apply",
+				"grape",
+				"apples",
+				"banana",
+			]);
+			expect(trie.getClosestLevenshteinSuggestions("")).toEqual([
+				"kiwi",
+				"apply",
+				"grape",
+				"apples",
+				"banana",
+			]);
 		});
 	});
 });

--- a/src/utils/tests/validation.spec.ts
+++ b/src/utils/tests/validation.spec.ts
@@ -6,6 +6,7 @@ import {
 	validateByRegex,
 	validateLength,
 	validateRange,
+	validateThemeShape,
 } from "@/utils/validation";
 
 describe("validateByRegex", () => {
@@ -264,5 +265,87 @@ describe("validate", () => {
 		for (const input of incorrectInputs) {
 			expect(validate(input, validationFunctions)).toBe(false);
 		}
+	});
+});
+describe("validateThemeShape", () => {
+	it("should return true when the two objects have the same shape", () => {
+		const first = {
+			colors: {
+				primary: "#FF0000",
+				secondary: "#00FF00",
+			},
+			fontSize: "16",
+		};
+
+		const second = {
+			colors: {
+				primary: "#FF0000",
+				secondary: "#00FF00",
+			},
+			fontSize: "16",
+		};
+
+		expect(validateThemeShape(first, second)).toBe(true);
+	});
+
+	it("should return false when the two objects have different shapes", () => {
+		const first = {
+			colors: {
+				primary: "#FF0000",
+				secondary: "#00FF00",
+			},
+			fontSize: "16",
+		};
+
+		const second = {
+			colors: {
+				primary: "#FF0000",
+			},
+			fontSize: "16",
+		};
+
+		expect(validateThemeShape(first, second)).toBe(false);
+	});
+
+	it("should return false when the values of the same key have different types", () => {
+		const first = {
+			colors: {
+				primary: "#FF0000",
+				secondary: "#00FF00",
+			},
+			fontSize: "16",
+		};
+
+		const second = {
+			colors: {
+				primary: "#FF0000",
+				secondary: "#0000FF",
+			},
+			fontSize: 16,
+		};
+
+		// @ts-ignore
+		expect(validateThemeShape(first, second)).toBe(false);
+	});
+
+	it("should return false when the values of nested data of the same key have different types", () => {
+		const first = {
+			colors: {
+				primary: null,
+				secondary: "#00FF00",
+			},
+			fontSize: "16",
+		};
+
+		const second = {
+			colors: {
+				primary: "#FF0000",
+				secondary: "#0000FF",
+			},
+			fontSize: 16,
+		};
+
+		// @ts-ignore
+		expect(validateThemeShape(first, second)).toBe(false);
 	});
 });

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -59,3 +59,20 @@ export function validate(
 	}
 	return true;
 }
+
+export function validateThemeShape<T extends object = RecursiveControlGroup>(
+	first: T,
+	second: T,
+): boolean {
+	for (const key in first) {
+		if (typeof first[key] === "object") {
+			if (!validateThemeShape(first[key] as T, second[key] as T)) {
+				return false;
+			}
+		} else if (typeof first[key] !== typeof second[key]) {
+			return false;
+		}
+	}
+
+	return true;
+}


### PR DESCRIPTION
Closes #45

## Changes
* Make the `<Text>` component have rounded borders
* Add a text component to import themes based on a debounce to the theme page.
* Add a button to export a theme which stringifies it then serializes it to base64
* If there are no suggested search results returned, get suggestions based on Levenshtein distance instead of random chance